### PR TITLE
Typecheck TypeScript in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,9 @@ jobs:
       - name: format-check
         run: pnpm run format --check
 
+      - name: typecheck
+        run: pnpm run typecheck
+
       - name: lint
         run: pnpm run lint
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "vitest --run",
     "format": "prettier .",
     "check": "pnpm format --write && tsc --noEmit && pnpm lint && pnpm test && pnpm build",
+    "typecheck": "tsc --noEmit",
     "drizzle:libsql": "drizzle-kit push --config ./drizzle.libsql.config.ts",
     "drizzle:d1-local": "drizzle-kit push --config ./drizzle.d1-local-backend.config.ts",
     "drizzle:d1-remote": "drizzle-kit push --config ./drizzle.d1-remote.config.ts"


### PR DESCRIPTION
Noticed this is failing on `mabels/backend`

Better to turn this on now while there are only 8 errors?